### PR TITLE
Remove remaining workflowr infrastructure.

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -1,5 +1,2 @@
 ^mr\.ash\.alpha\.Rproj$
 ^\.Rproj\.user$
-^_workflowr\.yml$
-^analysis$
-^docs$

--- a/_workflowr.yml
+++ b/_workflowr.yml
@@ -1,8 +1,0 @@
-# workflowr options
-# Version 1.4.0
-
-# The seed to use for random number generation. See ?set.seed for details.
-seed: 20190928
-# The working directory to build the R Markdown files. The path is relative to
-# _workflowr.yml. See ?rmarkdown::render for details.
-knit_root_dir: "."


### PR DESCRIPTION
I search GitHub for the file `_workflowr.yml` to count the number of workflowr projects. This repo is private, so it doesn't currently affect the count, but it would when made public.